### PR TITLE
Set FastCraft ASM to permissive

### DIFF
--- a/base-server/start.sh
+++ b/base-server/start.sh
@@ -33,6 +33,7 @@ done
 
 exec java -d64 -server -Xmn512m -Xms1g -Xmx10g \
   -Djava.net.preferIPv4Stack=true \
+  -Dfastcraft.asm.permissive=true \
   -XX:+AggressiveOpts \
   -XX:+UseG1GC \
   -XX:+DisableExplicitGC -XX:MaxGCPauseMillis=150 -XX:SurvivorRatio=8 \


### PR DESCRIPTION
Prep for Forge Essentials. We'll need to add Forge Essentials soon to let non-OP users use certain features such as CoFH Friends and Galacticraft's Space Race teams.