### PR TITLE
Disable ForgeEssentials Chat Filter

### DIFF
--- a/base/ForgeEssentials/Chat.cfg
+++ b/base/ForgeEssentials/Chat.cfg
@@ -1,0 +1,158 @@
+# Configuration file
+
+##########################################################################################################
+# Chat
+#--------------------------------------------------------------------------------------------------------#
+# Chat configuration
+##########################################################################################################
+
+Chat {
+    # Format for chat. Always needs to contain all 5 "%s" placeholders like the default!
+    S:ChatFormat=%s%s<%s>%s%s 
+
+    # Log all chat messages
+    B:LogChat=true
+
+    # Login message shown each time the player logs in (supports script arguments)
+    S:LoginMessage <
+        Welcome @player.
+        This server is running ForgeEssentials
+     >
+
+    # Welcome messages for new players. Can be color formatted (supports script arguments)
+    S:WelcomeMessage=New player @player joined the server!
+
+    ##########################################################################################################
+    # Gamemodes
+    #--------------------------------------------------------------------------------------------------------#
+    # Gamemode names
+    ##########################################################################################################
+
+    Gamemodes {
+        S:Adventure=adventure
+        S:Creative=creative
+        S:Survival=survival
+    }
+
+    mute {
+        # All commands in here will be blocked if the player is muted.
+        S:mutedCommands <
+            me
+         >
+    }
+
+    ##########################################################################################################
+    # IRC
+    #--------------------------------------------------------------------------------------------------------#
+    # Configure the built-in IRC bot here
+    ##########################################################################################################
+
+    IRC {
+        # List of privileged users that can use more commands via the IRC bot
+        S:admins <
+         >
+
+        # If enabled, allows usage of bot commands
+        B:allowCommands=true
+
+        # If enabled, allows usage of MC commands through the bot (only if the IRC user is in the admins list)
+        B:allowMcCommands=true
+
+        # Bot name
+        S:botName=FEIRCBot
+
+        # List of channels to connect to, together with the # character
+        S:channels <
+            #someChannelName
+         >
+
+        # Enable IRC interoperability?
+        B:enable=false
+
+        # Header for messages sent from IRC. Must contain one "%s"
+        S:ircHeader=[§cIRC§r]<%s> 
+
+        # Header for IRC events. Must NOT contain any "%s"
+        S:ircHeaderGlobal=[§cIRC§r] 
+
+        # Header for messages sent from MC to IRC. Must contain two "%s"
+        S:mcHeader=<%s> %s
+
+        # Header for messages sent with the /say command from MC to IRC. Must contain two "%s"
+        S:mcSayHeader=[%s] %s
+
+        # Delay between messages sent to IRC
+        I:messageDelay=0
+
+        # NickServ password
+        S:nickPassword=
+
+        # Server port
+        I:port=5555
+
+        # If enabled, ingame messages will be sent to IRC as well
+        B:sendMessages=false
+
+        # Server address
+        S:server=irc.something.com
+
+        # Server password
+        S:serverPassword=
+
+        # Show IRC events ingame (e.g., join, leave, kick, etc.)
+        B:showEvents=true
+
+        # Show game events in IRC (e.g., join, leave, death, etc.)
+        B:showGameEvents=true
+
+        # Show chat messages from IRC ingame
+        B:showMessages=true
+
+        # If set to true, sets connection to twitch mode
+        B:twitchMode=false
+    }
+
+    Censor {
+        # Replace censored words with this character
+        S:censorSymbol=#
+        B:enable=false
+
+        # Damage to a player when he uses a censored word
+        I:slapDamage=1
+
+        # Words to be censored. Prepend with ! to disable word boundary check.
+        S:words <
+            fuck\S*
+            bastard
+            moron
+            ass
+            asshole
+            bitch
+            shit
+         >
+    }
+
+    ##########################################################################################################
+    # TimedMessage
+    #--------------------------------------------------------------------------------------------------------#
+    # Automated spam
+    ##########################################################################################################
+
+    TimedMessage {
+        B:enabled=false
+
+        # Interval in seconds. 0 to disable
+        I:inverval=60
+
+        # Each line is 1 message. 
+        # You can use scripting arguments and color codes. 
+        # Using json messages (tellraw) is also supported
+        S:messages <
+            This server runs ForgeEssentials server management mod
+         >
+        B:shuffle=false
+    }
+
+}
+
+


### PR DESCRIPTION
Apparently its on by default and makes people mad.

This only adds a single config file, so nothing should be able to go wrong this time.