### PR TITLE
Enable oredictionary for tungsten.

### DIFF
--- a/base/config/Eln.cfg
+++ b/base/config/Eln.cfg
@@ -33,7 +33,7 @@ debug {
 
 
 dictionary {
-    B:tungsten=false
+    B:tungsten=true
 }
 
 


### PR DESCRIPTION
Should stop some ore processing from making ElnTungsten Ingots.