### PR TITLE
Undefault SoundFilters

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -152,7 +152,7 @@ rec {
       SoundFilters = {
         side = "CLIENT";
         required = false;
-        isDefault = true;
+        isDefault = false;
       };
       morpheus = {
         side = "SERVER";


### PR DESCRIPTION
SoundFilters and SoundPhysics don't like each other too much. I spoke to @Castone22 and he agrees with me that SoundPhysics is probably the one we'd want to have enabled by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/erisia/builder/36)
<!-- Reviewable:end -->
