### PR TITLE
Add Thaumcraft NEI Plugin

### DIFF
--- a/MODS.md
+++ b/MODS.md
@@ -1,5 +1,5 @@
 # Mods added via manifest
-## manifests/BR-Extras.json:
+## manifests\BR-Extras.json:
 - [AnimationAPI](https://minecraft.curseforge.com/projects/animationapi): 1.7.10-1.2.4
 - [Ars Magica 2](https://minecraft.curseforge.com/projects/ars-magica-2): 1.7.10_AM2-1.4.0.009
 - [Climate Control/Geographicraft](https://minecraft.curseforge.com/projects/climate-control-geographicraft): 0.8.2
@@ -18,7 +18,7 @@
 - [Streams](https://minecraft.curseforge.com/projects/streams): 0.2
 - [Thaumcraft Node Tracker](https://minecraft.curseforge.com/projects/thaumcraft-node-tracker): 1.7.10-1.1.2
 
-## manifests/cosmetic.json:
+## manifests\cosmetic.json:
 - [AmbientSounds](https://minecraft.curseforge.com/projects/ambientsounds): None
 ```diff
 - Not found
@@ -29,8 +29,9 @@
 - [Real Time Clock](https://minecraft.curseforge.com/projects/real-time-clock): 1.7.10-0.2
 - [Sound Filters](https://minecraft.curseforge.com/projects/sound-filters): 0.8_for_1.7.X
 - [SoundCap](https://minecraft.curseforge.com/projects/soundcap): 1.0
+- [Thaumcraft NEI Plugin](https://minecraft.curseforge.com/projects/thaumcraft-nei-plugin): 1.7.10-1.7a
 
-## manifests/tools.json:
+## manifests\tools.json:
 - [HelpFixer](https://minecraft.curseforge.com/projects/helpfixer): 1.0.7
 - [Inventory Tweaks](https://minecraft.curseforge.com/projects/inventory-tweaks): 1.59-dev-152
 - [JourneyMap](https://minecraft.curseforge.com/projects/journeymap-32274): 1.7.10-5.1.4p2-unlimited

--- a/manifests/cosmetic.json
+++ b/manifests/cosmetic.json
@@ -19,5 +19,9 @@
         "side": "client"
     },
     "garden-stuff": {},
-    "decocraft2": {}
+    "decocraft2": {},
+	"thaumcraft-nei-plugin": {
+		"side": "client",
+		"required": true
+	}
 }

--- a/manifests/cosmetic.nix
+++ b/manifests/cosmetic.nix
@@ -86,4 +86,18 @@
     "side" = "client";
     "md5" = "ce65914f0dc2e027d0aba17adc6c03eb";
   };
+  "thaumcraft-nei-plugin" = {
+    "src" = "https://minecraft.curseforge.com/projects/thaumcraft-nei-plugin/files/2241913/download";
+    "version" = "1.7.10-1.7a";
+    "title" = "Thaumcraft NEI Plugin";
+    "projectID" = 225095;
+    "required" = true;
+    "filename" = "thaumcraftneiplugin-1.7.10-1.7a.jar";
+    "dependencies" = [];
+    "encoded" = "thaumcraftneiplugin-1.7.10-1.7a.jar";
+    "projectPage" = "https://minecraft.curseforge.com/projects/thaumcraft-nei-plugin";
+    "type" = "remote";
+    "side" = "client";
+    "md5" = "f71559fa64c1996b03e796b660914637";
+  };
 }


### PR DESCRIPTION
This hides recipes people haven't unlocked yet in TC. Since they can't craft them without unlocking them anyway, this will save us problems with people trying to craft things then getting confused when they don't work. Also adds [?] shift click to arcane worktable, aspect information, and NEI recipe support for the arcane worktable, crucible, and infusion.

Also on a side note lxml is a bit of a chore to get working on Windows Python 2.7, any chance we can get a windows version that uses something else for parsing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/erisia/builder/40)
<!-- Reviewable:end -->
