### PR TITLE
enable world anchor crafting

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -251,6 +251,8 @@ rec {
       ''sed -i railcraft/railcraft.cfg -e "s/S:passive.fuel=minecraft:ender_pearl=12/S:passive.fuel=/" ''
       ''sed -i railcraft/railcraft.cfg -e "s/S:personal.fuel=minecraft:ender_pearl=12/S:personal.fuel=/" ''
       ''sed -i railcraft/railcraft.cfg -e "s/S:world.fuel=minecraft:ender_pearl=12/S:world.fuel=/" ''
+      # Enables the crafting of world anchors.
+      ''sed -i railcraft/railcraft.cfg -e "s/B:craftable=false/B:craftable=true/" ''
     ];
   };
 


### PR DESCRIPTION
hopefully I did this correctly 

this will enable world anchor crafting which will mostly be used for world anchor carts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/erisia/builder/41)
<!-- Reviewable:end -->
