### PR TITLE
Update Erisia.zs

### DIFF
--- a/base-e15/scripts/Erisia.zs
+++ b/base-e15/scripts/Erisia.zs
@@ -69,3 +69,7 @@ mods.botania.ElvenTrade.addRecipe(<dimdoors:Rift Signature>,
 
 // Plates.
 mods.gregtech.PlateBender.addRecipe(<Eln:Eln.sharedItem:7691>, <Eln:Eln.sharedItem:519>, 600, 40);
+
+//Allow conversion from Greg's Blue Topaz Blocks to AM2's Blue Topaz Blocks to fix some broken recipes and rituals.
+recipes.addShapeless(<arsmagica2:vinteumOre:7>, [<gregtech:gt.blockgem1:4>]);
+


### PR DESCRIPTION
Should allow conversion from Greg's Blue Topaz Blocks to AM2's Blue Topaz Blocks to fix some broken recipes and rituals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/erisia/builder/43)
<!-- Reviewable:end -->
