### PR TITLE
Update advancedRocketry.cfg

### DIFF
--- a/base/revelation/config/advRocketry/advancedRocketry.cfg
+++ b/base/revelation/config/advRocketry/advancedRocketry.cfg
@@ -11,6 +11,29 @@ asteroid {
         oreCopper
         oreTin
         oreRedstone
+        oreDiamond
+        oreSilver
+        oreLead
+        oreCoal
+        oreAluminum
+        oreNickel
+        oreCobalt
+        oreArdite
+        oreIridium
+        oreLapis
+        oreRutile
+        orePlatinum
+        oreDilithium
+        oreEmerald
+        oreQuartz
+        preQuartzBlack
+        oreCertusQuartz
+        oreYellorite
+        oreMagnesium
+        oreLithium
+        oreBoron
+        oreThorium
+        oreUranium
      >
 }
 
@@ -132,6 +155,28 @@ general {
         oreTin
         oreRedstone
         oreDiamond
+        oreSilver
+        oreLead
+        oreCoal
+        oreAluminum
+        oreNickel
+        oreCobalt
+        oreArdite
+        oreIridium
+        oreLapis
+        oreRutile
+        orePlatinum
+        oreDilithium
+        oreEmerald
+        oreQuartz
+        preQuartzBlack
+        oreCertusQuartz
+        oreYellorite
+        oreMagnesium
+        oreLithium
+        oreBoron
+        oreThorium
+        oreUranium
      >
 
     # True if the ores in laserDrillOres should be a blacklist, false for whitelist
@@ -163,7 +208,7 @@ general {
     B:sawMillCutVanillaWood=true
 
     # If true the Oxygen scrubbers require a consumable carbon collection cartridge
-    B:scrubberRequiresCartrige=true
+    B:scrubberRequiresCartrige=false
 
     # Amount of power per tick the solar generator should produce
     I:solarGeneratorMultiplier=1
@@ -233,6 +278,28 @@ general {
         oreCopper
         oreTin
         oreRedstone
+        oreSilver
+        oreLead
+        oreCoal
+        oreAluminum
+        oreNickel
+        oreCobalt
+        oreArdite
+        oreIridium
+        oreLapis
+        oreRutile
+        orePlatinum
+        oreDilithium
+        oreEmerald
+        oreQuartz
+        preQuartzBlack
+        oreCertusQuartz
+        oreYellorite
+        oreMagnesium
+        oreLithium
+        oreBoron
+        oreThorium
+        oreUranium
      >
 
     # True if the ores in geodeOres should be a blacklist, false for whitelist


### PR DESCRIPTION
Allows Advanced Rocketry mining methods to be more in line with other mods added. 
Geodes also make AR planets very promising as mining worlds which will help more people go into space.
The durability on scrubbers is just obnoxious and can force stations to be without air while being replaced.  