### PR TITLE
Asteroid Fix

### DIFF
--- a/base/revelation/config/advRocketry/asteroidConfig.xml
+++ b/base/revelation/config/advRocketry/asteroidConfig.xml
@@ -3,9 +3,96 @@
 		<ore itemStack="minecraft:iron_ore" chance="15" />
 		<ore itemStack="minecraft:gold_ore" chance="10" />
 		<ore itemStack="minecraft:redstone_ore" chance="10" />
+		<ore itemStack="minecraft:diamond_ore" chance="3" />
+		<ore itemStack="minecraft:emerald_ore" chance="3" />
+		<ore itemStack="minecraft:coal_ore" chance="10" />
+		<ore itemStack="minecraft:quartz_ore" chance="9"/>
+		<ore itemStack="appliedenergistics2:quartz_ore" chance="5" />
+		<ore itemStack="thermalfoundation:ore 0" chance="10" />
+		<ore itemStack="thermalfoundation:ore 1" chance="10" />
+		<ore itemStack="thermalfoundation:ore 2" chance="10" />
+		<ore itemStack="thermalfoundation:ore 3" chance="10" />
+		<ore itemStack="thermalfoundation:ore 4" chance="10" />
+		<ore itemStack="thermalfoundation:ore 5" chance="10" />
+		<ore itemStack="thermalfoundation:ore 6" chance="1" />
+		<ore itemStack="thermalfoundation:ore 7" chance="3" />
+		<ore itemStack="tconstruct:ore 0" chance="3" />
+		<ore itemStack="tconstruct:ore 1" chance="3" />
+		<ore itemStack="deepresonance:resonating_ore 0" chance="5" />
+		<ore itemStack="bigreactors:brore 0" chance="5" />
+		<ore itemStack="libvulpes:ore0 0" chance="4" />
+		<ore itemStack="libvulpes:ore0 8" chance="4" />
 	</asteroid>
-	<asteroid name="Iridium Enriched asteroid" distance="100" mass="25" massVariability="0.5" minLevel="0" probability="0.75" richness="0.2" richnessVariability="0.3">
-		<ore itemStack="minecraft:iron_ore" chance="25" />
-		<ore itemStack="libvulpes:ore0 10" chance="5" />
+	<asteroid name="Medium Asteroid" distance="13" mass="500" massVariability="0.5" minLevel="0" probability="7" richness="0.4" richnessVariability="0.5">
+		<ore itemStack="minecraft:iron_ore" chance="15" />
+		<ore itemStack="minecraft:gold_ore" chance="10" />
+		<ore itemStack="minecraft:redstone_ore" chance="10" />
+		<ore itemStack="minecraft:diamond_ore" chance="3" />
+		<ore itemStack="minecraft:emerald_ore" chance="3" />
+		<ore itemStack="minecraft:coal_ore" chance="10" />
+		<ore itemStack="minecraft:quartz_ore" chance="9"/>
+		<ore itemStack="appliedenergistics2:quartz_ore" chance="5" />
+		<ore itemStack="thermalfoundation:ore 0" chance="10" />
+		<ore itemStack="thermalfoundation:ore 1" chance="10" />
+		<ore itemStack="thermalfoundation:ore 2" chance="10" />
+		<ore itemStack="thermalfoundation:ore 3" chance="10" />
+		<ore itemStack="thermalfoundation:ore 4" chance="10" />
+		<ore itemStack="thermalfoundation:ore 5" chance="10" />
+		<ore itemStack="thermalfoundation:ore 6" chance="1" />
+		<ore itemStack="thermalfoundation:ore 7" chance="3" />
+		<ore itemStack="tconstruct:ore 0" chance="3" />
+		<ore itemStack="tconstruct:ore 1" chance="3" />
+		<ore itemStack="deepresonance:resonating_ore 0" chance="5" />
+		<ore itemStack="bigreactors:brore 0" chance="5" />
+		<ore itemStack="libvulpes:ore0 0" chance="4" />
+		<ore itemStack="libvulpes:ore0 8" chance="4" />
+	</asteroid>
+	<asteroid name="Large Asteroid" distance="15" mass="1500" massVariability="0.5" minLevel="0" probability="5" richness="0.6" richnessVariability="0.5">
+		<ore itemStack="minecraft:iron_ore" chance="15" />
+		<ore itemStack="minecraft:gold_ore" chance="10" />
+		<ore itemStack="minecraft:redstone_ore" chance="10" />
+		<ore itemStack="minecraft:diamond_ore" chance="3" />
+		<ore itemStack="minecraft:emerald_ore" chance="3" />
+		<ore itemStack="minecraft:coal_ore" chance="10" />
+		<ore itemStack="minecraft:quartz_ore" chance="9"/>
+		<ore itemStack="appliedenergistics2:quartz_ore" chance="5" />
+		<ore itemStack="thermalfoundation:ore 0" chance="10" />
+		<ore itemStack="thermalfoundation:ore 1" chance="10" />
+		<ore itemStack="thermalfoundation:ore 2" chance="10" />
+		<ore itemStack="thermalfoundation:ore 3" chance="10" />
+		<ore itemStack="thermalfoundation:ore 4" chance="10" />
+		<ore itemStack="thermalfoundation:ore 5" chance="10" />
+		<ore itemStack="thermalfoundation:ore 6" chance="1" />
+		<ore itemStack="thermalfoundation:ore 7" chance="3" />
+		<ore itemStack="tconstruct:ore 0" chance="3" />
+		<ore itemStack="tconstruct:ore 1" chance="3" />
+		<ore itemStack="deepresonance:resonating_ore 0" chance="5" />
+		<ore itemStack="bigreactors:brore 0" chance="5" />
+		<ore itemStack="libvulpes:ore0 0" chance="4" />
+		<ore itemStack="libvulpes:ore0 8" chance="4" />
+	</asteroid>
+		<asteroid name="Monster Asteroid" distance="20" mass="5000" massVariability="0.5" minLevel="0" probability="2" richness="0.8" richnessVariability="0.5">
+		<ore itemStack="minecraft:iron_ore" chance="15" />
+		<ore itemStack="minecraft:gold_ore" chance="10" />
+		<ore itemStack="minecraft:redstone_ore" chance="10" />
+		<ore itemStack="minecraft:diamond_ore" chance="3" />
+		<ore itemStack="minecraft:emerald_ore" chance="3" />
+		<ore itemStack="minecraft:coal_ore" chance="10" />
+		<ore itemStack="minecraft:quartz_ore" chance="9"/>
+		<ore itemStack="appliedenergistics2:quartz_ore" chance="5" />
+		<ore itemStack="thermalfoundation:ore 0" chance="10" />
+		<ore itemStack="thermalfoundation:ore 1" chance="10" />
+		<ore itemStack="thermalfoundation:ore 2" chance="10" />
+		<ore itemStack="thermalfoundation:ore 3" chance="10" />
+		<ore itemStack="thermalfoundation:ore 4" chance="10" />
+		<ore itemStack="thermalfoundation:ore 5" chance="10" />
+		<ore itemStack="thermalfoundation:ore 6" chance="1" />
+		<ore itemStack="thermalfoundation:ore 7" chance="3" />
+		<ore itemStack="tconstruct:ore 0" chance="3" />
+		<ore itemStack="tconstruct:ore 1" chance="3" />
+		<ore itemStack="deepresonance:resonating_ore 0" chance="5" />
+		<ore itemStack="bigreactors:brore 0" chance="5" />
+		<ore itemStack="libvulpes:ore0 0" chance="4" />
+		<ore itemStack="libvulpes:ore0 8" chance="4" />
 	</asteroid>
 </Asteroids>


### PR DESCRIPTION
whitelisting ore for the asteroids in the advrocketry.cfg config file actually doesn't spawn the new ore due to all of them having no "chance" to generate. Added in the new ore to asteroids and added medium, large, and monster sized asteroids while eliminating the iridium rich asteroid. 

For whatever reason the default only had two sizes which makes it lackluster for the amount of work needed to mine an asteroid. eg: small asteroid only has about 15 ore for the investment of launching a minimum of 3 satellites in space and building/fueling a mining rocket.

Chances of both ore and asteroid generation may need to be tuned.