### PR TITLE
Fix infinite mithriline plates bug with AR rolling machine

### DIFF
--- a/base/mm2/config/advRocketry/RollingMachine.xml
+++ b/base/mm2/config/advRocketry/RollingMachine.xml
@@ -289,7 +289,7 @@
 	</Recipe>
 	<Recipe timeRequired="300" power ="20">
 		<input>
-			<oreDict>ingotMithriline</oreDict>
+			<oreDict>ingotMithrilineMetal</oreDict>
 		</input>
 		<output>
 			<itemStack>essentialcraft:genitem 1 49</itemStack>


### PR DESCRIPTION
Fixed the oredict name of mithriline ingots to stop AR's rolling machine from spitting out infinite mithriline plates when powered.
The fixed recipe is in line with the plate recipes for the other EC4 metal plates in the Rolling Machine.