### PR TITLE
Disable showing named mob deaths

### DIFF
--- a/base/mm2/config/cofh/core/common.cfg
+++ b/base/mm2/config/cofh/core/common.cfg
@@ -88,7 +88,7 @@ General {
     B:EnableDismantleLogging=false
 
     # If TRUE, death messages are displayed for any named entity. [default: true]
-    B:EnableGenericDeathMessage=true
+    B:EnableGenericDeathMessage=false
 
     # Adjust this value to change the render update delay for most CoFH tiles. You should really only mess with this if you know what you're doing. This is a server-wide setting. [range: 80 ~ 1600, default: 160]
     I:TileUpdateDelay=160


### PR DESCRIPTION
Because burper and lute's mob farm is annoying me.