### PR TITLE
Allow 1:1 output.

### DIFF
--- a/base/mm2/config/immersivetech.cfg
+++ b/base/mm2/config/immersivetech.cfg
@@ -7,7 +7,7 @@ general {
         I:alternator_RfModifier=800
 
         # The max of Flux that the Alternator can output per each energy device connected
-        I:alternator_RfPerTick=4096
+        I:alternator_RfPerTick=63000
 
         # The max of Flux that the Alternator can store
         I:alternator_energyStorage=1200000


### PR DESCRIPTION
Allows the kinetic generator to actually be able to output the 62.9krf/t possible capability of the steam turbine rather than bottleneck the throughput.