### PR TITLE
Add more magnetic armor types

### DIFF
--- a/base/mm2/config/fp.cfg
+++ b/base/mm2/config/fp.cfg
@@ -45,16 +45,16 @@ intern {
 
 magnetism {
     # Magnetic boots
-    S:boots=minecraft:iron_boots,minecraft:chainmail_boots
+    S:boots=minecraft:iron_boots,minecraft:chainmail_boots,botania:manasteelhelm,botania:terrasteelhelm,botania:elementiumhelm,advancedrocketry:spacehelmet,enderio:item_dark_steel_helmet,enderio:item_end_steel_helmet,actuallyadditions:item_helm_crystal_white,pneumaticcraft:pneumatic_helmet,thermalfoundation:armor.helmet_nickel,thermalfoundation:armor.helmet_steel,thermalfoundation:armor.helmet_invar
 
     # Magnetic chestplates
-    S:chestplates=minecraft:iron_chestplate,minecraft:chainmail_chestplate
+    S:chestplates=minecraft:iron_chestplate,minecraft:chainmail_chestplate,botania:manasteelhelm,botania:terrasteelhelm,botania:elementiumhelm,advancedrocketry:spacehelmet,enderio:item_dark_steel_helmet,enderio:item_end_steel_helmet,actuallyadditions:item_helm_crystal_white,pneumaticcraft:pneumatic_helmet,thermalfoundation:armor.helmet_nickel,thermalfoundation:armor.helmet_steel,thermalfoundation:armor.helmet_invar
 
     # Magnetic helmets
-    S:helmets=minecraft:iron_helmet,minecraft:chainmail_helmet
+    S:helmets=minecraft:iron_helmet,minecraft:chainmail_helmet,botania:manasteellegs,botania:terrasteellegs,botania:elementiumlegs,advancedrocketry:spaceleggings,enderio:item_dark_steel_leggings,enderio:item_end_steel_leggings,actuallyadditions:item_pants_crystal_white,thermalfoundation:armor.legs_nickel,thermalfoundation:armor.legs_steel,thermalfoundation:armor.legs_invar
 
     # Magnetic leggings
-    S:leggings=minecraft:iron_leggings,minecraft:chainmail_leggings
+    S:leggings=minecraft:iron_leggings,minecraft:chainmail_leggings,botania:manasteelboots,botania:terrasteelboots,botania:elementiumboots,advancedrocketry:spaceboots,enderio:item_dark_steel_boots,enderio:item_end_steel_boots,actuallyadditions:item_boots_crystal_white,thermalfoundation:armor.boots_nickel,thermalfoundation:armor.boots_steel,thermalfoundation:armor.boots_invar
 }
 
 


### PR DESCRIPTION
Added modded armors containing iron to the list of magnetic armor. This will cause players wearing those armors to be attracted to magnetism in Futurepack from sources such as the Magnet Block and the Electromagnet.