### PR TITLE
Modify Mineralis range and speed.

### DIFF
--- a/base/mm2/config/astralsorcery.cfg
+++ b/base/mm2/config/astralsorcery.cfg
@@ -610,7 +610,7 @@ ritual_effects {
         S:mineralisPotencyMultiplier=1.0
 
         # Defines the radius (in blocks) in which the ritual will search for cleanStone to generate ores into. [range: 1 ~ 32, default: 8]
-        I:mineralisRange=14
+        I:mineralisRange=4
     }
 
     lucerna {


### PR DESCRIPTION
Greatly reduces the Minerals ritual diameter form 29 to 9 to help improve efficiency and be less silly.