### PR TITLE
Prevent improper mod interactions.

### DIFF
--- a/base/mm2/config/instantunify.cfg
+++ b/base/mm2/config/instantunify.cfg
@@ -12,6 +12,7 @@ general {
     S:blacklistMods <
         chisel
 	immersiveengineering
+	magneticraft
      >
 
     # Preferred Mods


### PR DESCRIPTION
Prevents magneticraft from interfering with nuclearcraft and normal lead block deconstructing.