### PR TITLE
Revert "Prevent improper mod interactions."

### DIFF
--- a/base/mm2/config/instantunify.cfg
+++ b/base/mm2/config/instantunify.cfg
@@ -12,7 +12,6 @@ general {
     S:blacklistMods <
         chisel
 	immersiveengineering
-	magneticraft
      >
 
     # Preferred Mods


### PR DESCRIPTION
Doesn't work as intended, and prevents lead from being properly converted. -.-