### PR TITLE
Boost minechem power capacity 10x

### DIFF
--- a/base/unabridged/config/minechem.cfg
+++ b/base/unabridged/config/minechem.cfg
@@ -1,0 +1,137 @@
+# Configuration file
+
+##########################################################################################################
+# blacklist
+#--------------------------------------------------------------------------------------------------------#
+# Blacklisting for item/block recipes. Format is "mod:itemOrBlock". Target oreDict entries with "ore:oreName". One entry per line. Names are case insensitive. Uses unlocalized names. Uses asterisk as a wildcard.
+##########################################################################################################
+
+blacklist {
+    # Add Decomposer Recipes for Chemical Fluids
+    B:decomposeFluidChemicals=true
+
+    # Blacklist decomposition of specific things. Examples "*:diamond", "minecraft:dragon_egg", "mekanism:*", "ore:ore*"
+    S:decomposition <
+        minecraft:dirt
+     >
+
+    # Blacklist synthesis of specific things. Examples "*:diamond", "minecraft:dragon_egg", "mekanism:*", "ore:ore*"
+    S:synthesis <
+        minecraft:diamond
+        ore:ore*
+        *:dragon_egg
+     >
+}
+
+
+##########################################################################################################
+# general
+#--------------------------------------------------------------------------------------------------------#
+# Misc settings
+##########################################################################################################
+
+general {
+    # Make your turtles smarter - they probably won't try to take over the world
+    B:advancedTurtleAI=false
+
+    # Allow automation of Minechem machines
+    B:allowAutomation=true
+
+    # Print debug info to the console
+    B:debugMode=false
+
+    # Enable Safe Machines
+    B:decaySafeMachines=true
+
+    # Add Molecule Effects to the item tooltip
+    B:displayMoleculeEffects=true
+
+    # Enable fluid Effects
+    B:fluidEffects=true
+
+    # Allow food spiking
+    B:foodSpiking=true
+
+    # Half-Life length multiplier, default 20
+    I:halfLifeMultiplier=20
+
+    # Allow two fluids reaction when they meet.
+    B:reactionFluidMeetFluid=true
+
+    # Allow one fluid and one item reaction when they meet.
+    B:reactionItemMeetFluid=true
+
+    # Enable recreational chemical effects
+    B:recreationalChemicalEffects=true
+
+    # NEI Support
+    B:supportNEI=true
+
+    # Enable chemical weapon effects
+    B:swordEffects=true
+
+    # Model update radius
+    I:updateRadius=20
+}
+
+
+##########################################################################################################
+# power
+#--------------------------------------------------------------------------------------------------------#
+# Set ratios and storage caps for power
+##########################################################################################################
+
+power {
+    # Energy used to decompose an item
+    I:costDecomposition=1000
+
+    # Multiplier for calculating fission cost
+    I:costFissionMultiplier=100
+
+    # Multiplier for calculating fusion cost
+    I:costFusionMultiplier=100
+
+    # Multiplier for calculating synthesis cost
+    I:costSythesisMultiplier=10
+
+    # Should machines require power
+    B:enable=true
+
+    # Max RF/t consumption of Minechem machines
+    I:energyPacketSize=1000
+
+    # Max power that the decomposer can hold
+    I:maxDecomposerStorage=100000
+
+    # Max power that the fission reactor can hold
+    I:maxFissionStorage=1000000
+
+    # Max power that the fusion reactor can hold
+    I:maxFusionStorage=1000000
+
+    # Max power that the synthesizer can hold
+    I:maxSynthesizerStorage=1000000
+
+    # Recipe Recursion Depth (higher for more complex recipes)
+    I:recursiveDepth=10
+}
+
+
+##########################################################################################################
+# worldgen
+#--------------------------------------------------------------------------------------------------------#
+# Configure how Minechem generates world features, like ore
+##########################################################################################################
+
+worldgen {
+    # Should Minechem generate ore
+    B:generateOre=true
+
+    # Size of uranium clusters
+    I:uraniumOreClusterSize=3
+
+    # How frequently will uranium be generated in a chunk
+    I:uraniumoredensity=5
+}
+
+


### PR DESCRIPTION
This is necessary as certain recipes are disabled by having power
requirements higher than the machines can store.  For example, certus
quartz.

This leaves those recipes untouched, but allows their use by expanding
the machine RF storage capacity.

cf. [this reddit thread](https://www.reddit.com/r/feedthebeast/comments/2m0cec/crackpack_1710_minechem_requiring_too_much_energy/) and particularly the final comment.