### PR TITLE
disable etfuturum enchanting table

### DIFF
--- a/base/elncognito/config/etfuturum.cfg
+++ b/base/elncognito/config/etfuturum.cfg
@@ -17,7 +17,7 @@ general {
     B:Doors=true
     B:"Dragon respawning"=true
     B:Elytra=true
-    B:"Enchanting Table"=true
+    B:"Enchanting Table"=false
     B:Endermite=true
     B:"Fancy Skulls"=true
     B:"Fences and Gates"=true


### PR DESCRIPTION
apparently exu division sigil ritual requires the vanilla enchanting table.