### PR TITLE
Remove Et Futura enchanting table from Elncognito

### DIFF
--- a/base/elncognito/config/etfuturum.cfg
+++ b/base/elncognito/config/etfuturum.cfg
@@ -17,7 +17,7 @@ general {
     B:Doors=true
     B:"Dragon respawning"=true
     B:Elytra=true
-    B:"Enchanting Table"=true
+    B:"Enchanting Table"=false
     B:Endermite=true
     B:"Fancy Skulls"=true
     B:"Fences and Gates"=true


### PR DESCRIPTION
Railcraft Admin Anchors need to be loaded by a palyer first, so they can load chunks on their own. Admin Anchors therefore stop working after each restart. Since the server restarts twice a day it is difficult to log in everytime. ChickenChunks loads at the same time the server starts.