### PR TITLE
Change fml.readTimeout

### DIFF
--- a/base/server/start.sh
+++ b/base/server/start.sh
@@ -137,7 +137,7 @@ echo $$ > server.pid
 java -d64 -server -Xmx@ram@ \
   "$@" \
   -Djava.net.preferIPv4Stack=true \
-  -Dfml.readTimeout=360 \
+  -Dfml.readTimeout=1800 \
   -Dfml.doNotBackup=true \
   -XX:+AggressiveOpts \
   -XX:+UseTransparentHugePages \


### PR DESCRIPTION
Assuming this timer does what we think it does, it appears from logs that this number is actually in *deci*seconds despite saying its in seconds.

Assumption comes from some tests with Random#8753 on the Discord. Figure this is worth the try to see if it works.