### PR TITLE
Update minecolonies.cfg

### DIFF
--- a/base/mc-eternal/config/minecolonies.cfg
+++ b/base/mc-eternal/config/minecolonies.cfg
@@ -549,7 +549,7 @@ general {
         I:townHallPaddingChunk=1
 
         # Independent from the colony protection, should explosions be turned off? [Default: true]
-        B:turnOffExplosionsInColonies=true
+        B:turnOffExplosionsInColonies=false
 
         # AI Update rate, increase to improve performance. [Default: 1]
         # Min: 1


### PR DESCRIPTION
turn off explosion protection so pirate ships can be exploded