### PR TITLE
Remove InstantUnify because there's no way for players to disable it

### DIFF
--- a/manifest/e27.nix
+++ b/manifest/e27.nix
@@ -2246,23 +2246,6 @@
         "sha256" = "6a0ade35d7827072761892943b7f9a363e59f5aa65e2160a450b5106d8db1252";
         "size" = 858298;
     };
-    "instantunify" = {
-        "title" = "InstantUnify";
-        "name" = "instantunify";
-        "id" = 277047;
-        "side" = "both";
-        "required" = true;
-        "default" = true;
-        "deps" = [];
-        "filename" = "instantunify-1.12.2-1.1.2.jar";
-        "encoded" = "instantunify-1.12.2-1.1.2.jar";
-        "page" = "https://www.curseforge.com/minecraft/mc-mods/instantunify";
-        "src" = "https://media.forgecdn.net/files/2578/325/instantunify-1.12.2-1.1.2.jar";
-        "type" = "remote";
-        "md5" = "edd6718ffee3f11039c146d0cba47424";
-        "sha256" = "f627e2149a0277b5dc1402edcb57918e66ecf0ce055df5c5e89980c8133db8a2";
-        "size" = 10301;
-    };
     "instrumental-mobs" = {
         "title" = "Instrumental Mobs";
         "name" = "instrumental-mobs";

--- a/manifest/mc-eternal.yaml
+++ b/manifest/mc-eternal.yaml
@@ -487,10 +487,6 @@ mods:
     id: 251396
     files:
       - id: 2537265
-  - name: instantunify
-    id: 277047
-    files:
-      - id: 2578325
   - name: instrumental-mobs
     id: 299602
     files:


### PR DESCRIPTION
While this mod is usually convenient, there are times when you don't want ores/ingots to be converted as soon as they enter your inventory. For example, the mod makes it impossible to configure certain item filters without using a fuzzy match. It also prevents players from using certain blocks for decoration, as they will instantly be converted to a different variant.

As there are many ways to manually convert between ore dictionary variants, this mod should be removed for converting when not wanted.