### PR TITLE
Revert "Make Simple Voice Chat optional"

### DIFF
--- a/manifest/e28.nix
+++ b/manifest/e28.nix
@@ -4359,7 +4359,7 @@
         "name" = "simple-voice-chat";
         "id" = 416089;
         "side" = "both";
-        "required" = false;
+        "required" = true;
         "default" = true;
         "deps" = [];
         "filename" = "voicechat-1.16.5-1.6.2.jar";

--- a/manifest/e28.yml
+++ b/manifest/e28.yml
@@ -33,7 +33,6 @@ mods:
       - id: 3221978
   - name: simple-voice-chat
     id: 416089
-    required: false
     files:
       - id: 3362964
   - name: dcintegration


### PR DESCRIPTION
Reverts Erisia/builder#239

Curseforge page mentions that this mod should be optional on clients, however it appears to not actually be optional if we're using Forge.