### PR TITLE
Remove default JEI bookmarks

### DIFF
--- a/base/enigmatica6/config/jei/bookmarks.ini
+++ b/base/enigmatica6/config/jei/bookmarks.ini
@@ -1,4 +1,0 @@
-T:{id:"upgrade_aquatic:driftwood_bookshelf",Count:1b}
-T:{id:"pneumaticcraft:reinforced_stone",Count:1b}
-T:{id:"tconstruct:cobalt_ingot",Count:1b}
-T:{id:"tconstruct:copper_ingot",Count:1b}


### PR DESCRIPTION
I have no idea why, but the server pack that the base configs were copied from seems to have default bookmarks set for JEI. This removes those.