### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/base/e24/config/quark.cfg
+++ b/base/e24/config/quark.cfg
@@ -2790,7 +2790,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/e29/config/DLDungeonsJBG/nbt.cfg
+++ b/base/e29/config/DLDungeonsJBG/nbt.cfg
@@ -8,7 +8,7 @@
 #
 #I'm not giving a full NBT course here -- I'm just learning that myself, but below are some examples.
 #More info can be found online in places such as the Minecraft Wiki
-#This is a good start: http://minecraft.gamepedia.com/Player.dat_format#Item_structure
+#This is a good start: http://minecraft.wiki/w/Player.dat_format#Item_structure
 #
 #Whether or not this might latter be applicable to blocks or mobs has not been decided; 
 #For now NBT can only be used for loot items.

--- a/base/e29/config/capsule.cfg
+++ b/base/e29/config/capsule.cfg
@@ -100,7 +100,7 @@ loots {
 
     # List of loot tables that will eventually reward a capsule.
     #  Example of valid loot tables : gameplay/fishing/treasure, chests/spawn_bonus_chest, entities/villager (killing a villager).
-    # Also see https://minecraft.gamepedia.com/Loot_table#List_of_loot_tables.
+    # Also see https://minecraft.wiki/w/Loot_table#List_of_loot_tables.
     S:lootTablesList <
         minecraft:chests/abandoned_mineshaft
         minecraft:chests/desert_pyramid

--- a/base/e30/config/quark-common.toml
+++ b/base/e30/config/quark-common.toml
@@ -303,7 +303,7 @@
 		#<id>,<level>,<min_price>,<max_price>,<color>,<name>
 		#
 		#With the following descriptions:
-		# - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+		# - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
 		# - <level> being the Cartographer villager level required for the map to be unlockable
 		# - <min_price> being the cheapest (in Emeralds) the map can be
 		# - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/elncognito/config/RTG/biomes/abyssalcraft.cfg
+++ b/base/elncognito/config/RTG/biomes/abyssalcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,34 +110,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -147,13 +147,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -201,34 +201,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -238,13 +238,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -289,34 +289,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -332,13 +332,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -383,44 +383,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -465,44 +465,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/arsmagica.cfg
+++ b/base/elncognito/config/RTG/biomes/arsmagica.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/atg.cfg
+++ b/base/elncognito/config/RTG/biomes/atg.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/biomesoplenty.cfg
+++ b/base/elncognito/config/RTG/biomes/biomesoplenty.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1267,44 +1267,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1349,44 +1349,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1434,44 +1434,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1519,44 +1519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1601,44 +1601,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1686,44 +1686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1771,44 +1771,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1853,44 +1853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1938,44 +1938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2023,44 +2023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2105,44 +2105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2187,44 +2187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2269,44 +2269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2354,44 +2354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2439,44 +2439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2521,44 +2521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2606,44 +2606,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2688,44 +2688,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2773,44 +2773,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2855,44 +2855,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2937,44 +2937,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3022,44 +3022,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3104,44 +3104,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3189,44 +3189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3271,44 +3271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3356,44 +3356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3438,44 +3438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3520,44 +3520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3602,44 +3602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3684,44 +3684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3769,44 +3769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3854,44 +3854,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3939,44 +3939,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4024,44 +4024,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4109,44 +4109,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4191,44 +4191,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4273,44 +4273,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4355,44 +4355,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4437,44 +4437,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4519,44 +4519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4604,44 +4604,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4686,44 +4686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4768,44 +4768,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4853,44 +4853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4938,44 +4938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5023,44 +5023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5105,44 +5105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5187,44 +5187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5269,44 +5269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5354,44 +5354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5439,44 +5439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5521,44 +5521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5603,44 +5603,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5685,44 +5685,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5767,44 +5767,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5852,44 +5852,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5934,44 +5934,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6016,44 +6016,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6098,44 +6098,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6180,44 +6180,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6262,44 +6262,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6344,44 +6344,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/buildcraft.cfg
+++ b/base/elncognito/config/RTG/biomes/buildcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/chromaticraft.cfg
+++ b/base/elncognito/config/RTG/biomes/chromaticraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/eccentricbiomes.cfg
+++ b/base/elncognito/config/RTG/biomes/eccentricbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -763,44 +763,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -845,44 +845,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -927,44 +927,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1009,44 +1009,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1091,44 +1091,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1173,44 +1173,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1255,44 +1255,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/enhancedbiomes.cfg
+++ b/base/elncognito/config/RTG/biomes/enhancedbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1015,44 +1015,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1097,44 +1097,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2090,44 +2090,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2172,44 +2172,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2503,44 +2503,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2588,44 +2588,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2670,44 +2670,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2752,44 +2752,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2834,44 +2834,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2916,44 +2916,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3247,44 +3247,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3329,44 +3329,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3411,44 +3411,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3493,44 +3493,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3575,44 +3575,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3657,44 +3657,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3739,44 +3739,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3821,44 +3821,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3903,44 +3903,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3985,44 +3985,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4067,44 +4067,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4149,44 +4149,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4231,44 +4231,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4313,44 +4313,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4395,44 +4395,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4477,44 +4477,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4559,44 +4559,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4641,44 +4641,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4723,44 +4723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4805,44 +4805,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4887,44 +4887,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4969,44 +4969,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5054,44 +5054,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5139,44 +5139,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5224,44 +5224,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5309,44 +5309,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5394,44 +5394,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5476,44 +5476,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5558,44 +5558,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5640,44 +5640,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5722,44 +5722,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5804,44 +5804,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5886,44 +5886,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5968,44 +5968,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6050,44 +6050,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6132,44 +6132,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6214,44 +6214,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6299,44 +6299,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6384,44 +6384,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6466,44 +6466,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6548,44 +6548,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6630,44 +6630,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6712,44 +6712,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6794,44 +6794,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6876,44 +6876,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6958,44 +6958,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7040,44 +7040,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7122,44 +7122,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7204,44 +7204,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7286,44 +7286,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7368,44 +7368,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/extrabiomes.cfg
+++ b/base/elncognito/config/RTG/biomes/extrabiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -930,44 +930,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1012,44 +1012,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1094,44 +1094,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1176,44 +1176,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1258,44 +1258,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1340,44 +1340,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1422,44 +1422,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1507,44 +1507,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2002,44 +2002,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2084,44 +2084,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2166,44 +2166,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2248,44 +2248,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/flowercraft.cfg
+++ b/base/elncognito/config/RTG/biomes/flowercraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/forgottennature.cfg
+++ b/base/elncognito/config/RTG/biomes/forgottennature.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/growthcraft.cfg
+++ b/base/elncognito/config/RTG/biomes/growthcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/highlands.cfg
+++ b/base/elncognito/config/RTG/biomes/highlands.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -687,44 +687,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1759,44 +1759,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1841,44 +1841,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1923,44 +1923,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2087,44 +2087,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2169,44 +2169,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2500,44 +2500,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2582,44 +2582,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2664,44 +2664,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2746,44 +2746,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2828,44 +2828,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2913,44 +2913,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3244,44 +3244,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3326,44 +3326,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3408,44 +3408,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3490,44 +3490,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/hotwatermod.cfg
+++ b/base/elncognito/config/RTG/biomes/hotwatermod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/icecreammod.cfg
+++ b/base/elncognito/config/RTG/biomes/icecreammod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/industrialtechnologies.cfg
+++ b/base/elncognito/config/RTG/biomes/industrialtechnologies.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,44 +113,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/inthedarkness.cfg
+++ b/base/elncognito/config/RTG/biomes/inthedarkness.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/ridiculousworld.cfg
+++ b/base/elncognito/config/RTG/biomes/ridiculousworld.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -116,44 +116,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -280,44 +280,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -362,44 +362,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -444,44 +444,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -526,44 +526,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/sugiforest.cfg
+++ b/base/elncognito/config/RTG/biomes/sugiforest.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/thaumcraft.cfg
+++ b/base/elncognito/config/RTG/biomes/thaumcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/tofucraft.cfg
+++ b/base/elncognito/config/RTG/biomes/tofucraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/vampirism.cfg
+++ b/base/elncognito/config/RTG/biomes/vampirism.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/biomes/vanilla.cfg
+++ b/base/elncognito/config/RTG/biomes/vanilla.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,34 +113,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -150,13 +150,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -204,34 +204,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -241,13 +241,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -295,44 +295,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -380,34 +380,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -417,13 +417,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -468,44 +468,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -553,44 +553,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -638,44 +638,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -723,44 +723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -805,34 +805,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -842,13 +842,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -893,44 +893,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -975,44 +975,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1057,44 +1057,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1142,34 +1142,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1185,13 +1185,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1239,34 +1239,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1282,13 +1282,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1333,34 +1333,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1376,13 +1376,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1430,34 +1430,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1467,13 +1467,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1518,34 +1518,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1555,13 +1555,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1609,34 +1609,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1646,13 +1646,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1700,34 +1700,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1737,13 +1737,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1791,34 +1791,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1828,13 +1828,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1879,34 +1879,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1916,13 +1916,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1967,44 +1967,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2049,34 +2049,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2092,13 +2092,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2146,44 +2146,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2240,44 +2240,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2328,34 +2328,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2365,13 +2365,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2419,44 +2419,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2504,44 +2504,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2592,44 +2592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2680,44 +2680,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2765,44 +2765,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2850,44 +2850,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2935,44 +2935,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3017,44 +3017,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3099,44 +3099,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3181,44 +3181,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3263,44 +3263,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3345,44 +3345,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3427,44 +3427,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3509,44 +3509,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3591,44 +3591,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3673,34 +3673,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -3710,13 +3710,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3761,44 +3761,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3846,44 +3846,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3928,44 +3928,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4016,34 +4016,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4053,13 +4053,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4107,34 +4107,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4144,13 +4144,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4198,34 +4198,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4235,13 +4235,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4289,44 +4289,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4371,44 +4371,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4453,44 +4453,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4535,44 +4535,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4617,44 +4617,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4702,44 +4702,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4787,44 +4787,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4872,44 +4872,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4957,44 +4957,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5042,44 +5042,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/elncognito/config/RTG/rtg.cfg
+++ b/base/elncognito/config/RTG/rtg.cfg
@@ -387,7 +387,7 @@ trees {
     B:"Allow Trees to Generate on Sand"=false
 
     # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-    # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+    # For more information, visit http://minecraft.wiki/w/Wood#Block_data
     #  [default: true]
     B:"Allow bark-covered logs"=true
 }

--- a/base/enigmatica2/config/quark.cfg
+++ b/base/enigmatica2/config/quark.cfg
@@ -2171,7 +2171,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/alps.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/alps.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/bambooforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/bambooforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/bayou.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/bayou.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/bog.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/bog.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/borealforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/borealforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/brushland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/brushland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/chaparral.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/chaparral.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/cherryblossomgrove.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/cherryblossomgrove.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/colddesert.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/colddesert.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/coniferousforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/coniferousforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/coralreef.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/coralreef.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/crag.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/crag.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/deadforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/deadforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/deadswamp.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/deadswamp.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/eucalyptusforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/eucalyptusforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/fen.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/fen.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/flowerisland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/flowerisland.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/glacier.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/glacier.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/grassland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/grassland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/gravelbeach.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/gravelbeach.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/grove.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/grove.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/heathland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/heathland.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/highland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/highland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/kelpforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/kelpforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/landoflakes.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/landoflakes.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/lavenderfields.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/lavenderfields.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/lushdesert.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/lushdesert.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/lushswamp.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/lushswamp.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/mangrove.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/mangrove.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/maplewoods.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/maplewoods.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/marsh.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/marsh.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/meadow.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/meadow.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/moor.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/moor.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/mountainfoothills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/mountainfoothills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/mountainpeaks.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/mountainpeaks.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/mysticgrove.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/mysticgrove.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/oasis.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/oasis.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/ominouswoods.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/ominouswoods.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/orchard.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/orchard.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/originisland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/originisland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/outback.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/outback.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/overgrowncliffs.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/overgrowncliffs.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/prairie.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/prairie.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/quagmire.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/quagmire.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/rainforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/rainforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/redwoodforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/redwoodforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/sacredsprings.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/sacredsprings.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/seasonalforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/seasonalforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/shield.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/shield.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/shrubland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/shrubland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/snowyconiferousforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/snowyconiferousforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/snowyforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/snowyforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/steppe.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/steppe.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/temperaterainforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/temperaterainforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/tropicalisland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/tropicalisland.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/tropicalrainforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/tropicalrainforest.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/tundra.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/tundra.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/volcanicisland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/volcanicisland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/wasteland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/wasteland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/wetland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/wetland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/woodland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/woodland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/biomesoplenty/xericshrubland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/biomesoplenty/xericshrubland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/beach.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/beach.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/birchforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/birchforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/birchforesthills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/birchforesthills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/birchforesthillsm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/birchforesthillsm.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/birchforestm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/birchforestm.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/coldbeach.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/coldbeach.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/coldtaiga.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/coldtaiga.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/coldtaigahills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/coldtaigahills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/coldtaigam.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/coldtaigam.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/deepocean.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/deepocean.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,28 +99,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/desert.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/desert.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: minecraft:sandstone]
         S:"Filler Block ID"=minecraft:sandstone
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/deserthills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/deserthills.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/desertm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/desertm.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/extremehills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/extremehills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,42 +105,42 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }
 
     "mix filler block" {
         # If you want to change this biome's mix filler block (the block underneath the mix block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Filler Block ID"=
 
         # If you're using a custom mix filler block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix filler block, you would enter minecraft:dirt for the Mix Filler Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Filler Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsedge.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsedge.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,42 +105,42 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }
 
     "mix filler block" {
         # If you want to change this biome's mix filler block (the block underneath the mix block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Filler Block ID"=
 
         # If you're using a custom mix filler block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix filler block, you would enter minecraft:dirt for the Mix Filler Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Filler Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsm.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,42 +99,42 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }
 
     "mix filler block" {
         # If you want to change this biome's mix filler block (the block underneath the mix block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Filler Block ID"=
 
         # If you're using a custom mix filler block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix filler block, you would enter minecraft:dirt for the Mix Filler Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Filler Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsplus.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsplus.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsplusm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/extremehillsplusm.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,28 +99,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/flowerforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/flowerforest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/forest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/forest.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/foresthills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/foresthills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/frozenocean.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/frozenocean.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,28 +99,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/frozenriver.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/frozenriver.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/icemountains.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/icemountains.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,42 +99,42 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }
 
     "mix filler block" {
         # If you want to change this biome's mix filler block (the block underneath the mix block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Filler Block ID"=
 
         # If you're using a custom mix filler block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix filler block, you would enter minecraft:dirt for the Mix Filler Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Filler Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/iceplains.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/iceplains.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/iceplainsspikes.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/iceplainsspikes.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/jungle.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/jungle.cfg
@@ -66,28 +66,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -95,14 +95,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -110,28 +110,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/jungleedge.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/jungleedge.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/jungleedgem.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/jungleedgem.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/junglehills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/junglehills.cfg
@@ -66,28 +66,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -95,14 +95,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -110,14 +110,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/junglem.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/junglem.cfg
@@ -66,28 +66,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -95,14 +95,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -110,14 +110,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/megasprucetaiga.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/megasprucetaiga.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/megataiga.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/megataiga.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/megataigahills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/megataigahills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesa.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesa.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesabryce.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesabryce.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateau.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateau.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateauf.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateauf.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateaufm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateaufm.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateaum.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mesaplateaum.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mushroomisland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mushroomisland.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/mushroomislandshore.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/mushroomislandshore.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/ocean.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/ocean.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,28 +99,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/plains.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/plains.cfg
@@ -70,28 +70,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -114,14 +114,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/redwoodtaigahillsm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/redwoodtaigahillsm.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/river.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/river.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/roofedforest.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/roofedforest.cfg
@@ -66,28 +66,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -95,14 +95,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -110,28 +110,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/roofedforestm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/roofedforestm.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/savanna.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/savanna.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/savannam.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/savannam.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/savannaplateau.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/savannaplateau.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/savannaplateaum.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/savannaplateaum.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/stonebeach.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/stonebeach.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/sunflowerplains.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/sunflowerplains.cfg
@@ -55,28 +55,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -84,14 +84,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -99,14 +99,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/swampland.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/swampland.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/swamplandm.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/swamplandm.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,14 +105,14 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/taiga.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/taiga.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/taigahills.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/taigahills.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/biomes/vanilla/taigam.cfg
+++ b/base/farmingvalley/config/RTG/biomes/vanilla/taigam.cfg
@@ -61,28 +61,28 @@ surfaces {
 
     "top block" {
         # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Top Block ID"=
 
         # If you're using a custom top block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Top Block Meta (Data Value)"=0
     }
 
     "filler block" {
         # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Filler Block ID"=
 
         # If you're using a custom filler block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Filler Block Meta (Data Value)"=0
     }
@@ -90,14 +90,14 @@ surfaces {
     "cliff stone block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Stone Block ID"=
 
         # If you're using a custom cliff stone block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Stone Block Meta (Data Value)"=0
     }
@@ -105,28 +105,28 @@ surfaces {
     "cliff cobble block" {
         # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
         # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Cliff Cobble Block ID"=
 
         # If you're using a custom cliff cobble block, enter its numeric data value here.
         # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
         # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Cliff Cobble Block Meta (Data Value)"=0
     }
 
     "mix top block" {
         # If you want to change this biome's mix block, enter a valid block ID here (e.g. minecraft:grass).
-        # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
         #  [default: ]
         S:"Mix Block ID"=
 
         # If you're using a custom mix block, enter its numeric data value here.
         # For example, if you want to use podzol for this biome's mix block, you would enter minecraft:dirt for the Mix Block ID,
         # and you would enter 2 here, because podzol has a data value of 2. (For most blocks, this value will be 0.)
-        # For more info, visit http://minecraft.gamepedia.com/Data_values
+        # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
         #  [range: 0 ~ 15, default: 0]
         I:"Mix Block Meta (Data Value)"=0
     }

--- a/base/farmingvalley/config/RTG/rtg.cfg
+++ b/base/farmingvalley/config/RTG/rtg.cfg
@@ -465,7 +465,7 @@ trees {
     B:"Allow Trees to Generate on Sand"=false
 
     # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-    # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+    # For more information, visit http://minecraft.wiki/w/Wood#Block_data
     #  [default: true]
     B:"Allow bark-covered logs"=true
 

--- a/base/mc-eternal/config/DLDungeonsJBG/nbt.cfg
+++ b/base/mc-eternal/config/DLDungeonsJBG/nbt.cfg
@@ -8,7 +8,7 @@
 #
 #I'm not giving a full NBT course here -- I'm just learning that myself, but below are some examples.
 #More info can be found online in places such as the Minecraft Wiki
-#This is a good start: http://minecraft.gamepedia.com/Player.dat_format#Item_structure
+#This is a good start: http://minecraft.wiki/w/Player.dat_format#Item_structure
 #
 #Whether or not this might latter be applicable to blocks or mobs has not been decided; 
 #For now NBT can only be used for loot items.

--- a/base/mc-eternal/config/capsule.cfg
+++ b/base/mc-eternal/config/capsule.cfg
@@ -322,7 +322,7 @@ loots {
 
     # List of loot tables that will eventually reward a capsule.
     #  Example of valid loot tables : gameplay/fishing/treasure, chests/spawn_bonus_chest, entities/villager (killing a villager).
-    # Also see https://minecraft.gamepedia.com/Loot_table#List_of_loot_tables.
+    # Also see https://minecraft.wiki/w/Loot_table#List_of_loot_tables.
     S:lootTablesList <
         minecraft:chests/abandoned_mineshaft
         minecraft:chests/desert_pyramid

--- a/base/mc-eternal/config/hats.cfg
+++ b/base/mc-eternal/config/hats.cfg
@@ -79,7 +79,7 @@ globaloptions {
 ##########################################################################################################
 # keybind
 #--------------------------------------------------------------------------------------------------------#
-# If you're reading this in the config file, I would strongly recommend changing the keybinds in-game.\niChunUtil uses custom keybinds. Go to the controls/keybinds page and click on the bottom right corner.\n\nIf you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.\nFor key codes go to: http://minecraft.gamepedia.com/Key_codes \nExample: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt (On a QWERTY keyboard).
+# If you're reading this in the config file, I would strongly recommend changing the keybinds in-game.\niChunUtil uses custom keybinds. Go to the controls/keybinds page and click on the bottom right corner.\n\nIf you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.\nFor key codes go to: http://minecraft.wiki/w/Key_codes \nExample: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt (On a QWERTY keyboard).
 ##########################################################################################################
 
 keybind {

--- a/base/mc-eternal/config/ichunutil_keybinds.cfg
+++ b/base/mc-eternal/config/ichunutil_keybinds.cfg
@@ -7,7 +7,7 @@
 # iChunUtil uses custom keybinds. Go to the controls/keybinds page and click on the bottom right corner.
 # 
 # If you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.
-# For key codes go to: http://minecraft.gamepedia.com/Key_codes 
+# For key codes go to: http://minecraft.wiki/w/Key_codes 
 # Example: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt (On a QWERTY keyboard).
 ##########################################################################################################
 

--- a/base/mc-eternal/config/mattdahepic/mdecore.cfg
+++ b/base/mc-eternal/config/mattdahepic/mdecore.cfg
@@ -48,7 +48,7 @@ commands {
 
 general {
     # A message to be sent to the player every time they join the server.
-    # Supports color codes as specified at http://minecraft.gamepedia.com/Formatting_codes#Color_codes
+    # Supports color codes as specified at http://minecraft.wiki/w/Formatting_codes#Color_codes
     # If this string is empty no message will be sent.
     S:loginMessage=
 }

--- a/base/mc-eternal/config/portalgun.cfg
+++ b/base/mc-eternal/config/portalgun.cfg
@@ -30,7 +30,7 @@ clientonly {
 ##########################################################################################################
 # keybind
 #--------------------------------------------------------------------------------------------------------#
-# If you're reading this in the config file, I would strongly recommend changing the keybinds in-game.\niChunUtil uses custom keybinds. Go to the controls/keybinds page and click on the bottom right corner.\n\nIf you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.\nFor key codes go to: http://minecraft.gamepedia.com/Key_codes \nExample: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt (On a QWERTY keyboard).
+# If you're reading this in the config file, I would strongly recommend changing the keybinds in-game.\niChunUtil uses custom keybinds. Go to the controls/keybinds page and click on the bottom right corner.\n\nIf you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.\nFor key codes go to: http://minecraft.wiki/w/Key_codes \nExample: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt (On a QWERTY keyboard).
 ##########################################################################################################
 
 keybind {

--- a/base/mc-eternal/config/quark.cfg
+++ b/base/mc-eternal/config/quark.cfg
@@ -3046,7 +3046,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/mettle/config/quark.cfg
+++ b/base/mettle/config/quark.cfg
@@ -2435,7 +2435,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/mm2/config/quark.cfg
+++ b/base/mm2/config/quark.cfg
@@ -2028,7 +2028,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/revelation/config/quark.cfg
+++ b/base/revelation/config/quark.cfg
@@ -1997,7 +1997,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/sv/config/quark.cfg
+++ b/base/sv/config/quark.cfg
@@ -2899,7 +2899,7 @@ world {
         # <id>,<level>,<min_price>,<max_price>,<color>,<name>
         # 
         # With the following descriptions:
-        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.gamepedia.com/Biome#Biome_IDs
+        #  - <id> being the biome's ID NAME. You can find vanilla names here - https://minecraft.wiki/w/Biome#Biome_IDs
         #  - <level> being the Cartographer villager level required for the map to be unlockable
         #  - <min_price> being the cheapest (in Emeralds) the map can be
         #  - <max_price> being the most expensive (in Emeralds) the map can be

--- a/base/tppi2/config/RTG/biomes/abyssalcraft.cfg
+++ b/base/tppi2/config/RTG/biomes/abyssalcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,34 +110,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -147,13 +147,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -201,34 +201,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -238,13 +238,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -289,34 +289,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -332,13 +332,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -383,44 +383,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -465,44 +465,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/arsmagica.cfg
+++ b/base/tppi2/config/RTG/biomes/arsmagica.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/atg.cfg
+++ b/base/tppi2/config/RTG/biomes/atg.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/biomesoplenty.cfg
+++ b/base/tppi2/config/RTG/biomes/biomesoplenty.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1267,44 +1267,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1349,44 +1349,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1434,44 +1434,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1519,44 +1519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1601,44 +1601,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1686,44 +1686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1771,44 +1771,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1853,44 +1853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1938,44 +1938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2023,44 +2023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2105,44 +2105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2187,44 +2187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2269,44 +2269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2354,44 +2354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2439,44 +2439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2521,44 +2521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2606,44 +2606,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2688,44 +2688,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2773,44 +2773,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2855,44 +2855,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2937,44 +2937,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3022,44 +3022,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3104,44 +3104,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3189,44 +3189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3271,44 +3271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3356,44 +3356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3438,44 +3438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3520,44 +3520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3602,44 +3602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3684,44 +3684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3769,44 +3769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3854,44 +3854,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3939,44 +3939,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4024,44 +4024,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4109,44 +4109,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4191,44 +4191,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4273,44 +4273,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4355,44 +4355,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4437,44 +4437,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4519,44 +4519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4604,44 +4604,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4686,44 +4686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4768,44 +4768,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4853,44 +4853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4938,44 +4938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5023,44 +5023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5105,44 +5105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5187,44 +5187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5269,44 +5269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5354,44 +5354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5439,44 +5439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5521,44 +5521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5603,44 +5603,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5685,44 +5685,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5767,44 +5767,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5852,44 +5852,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5934,44 +5934,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6016,44 +6016,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6098,44 +6098,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6180,44 +6180,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6262,44 +6262,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6344,44 +6344,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/buildcraft.cfg
+++ b/base/tppi2/config/RTG/biomes/buildcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/chromaticraft.cfg
+++ b/base/tppi2/config/RTG/biomes/chromaticraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/eccentricbiomes.cfg
+++ b/base/tppi2/config/RTG/biomes/eccentricbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -763,44 +763,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -845,44 +845,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -927,44 +927,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1009,44 +1009,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1091,44 +1091,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1173,44 +1173,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1255,44 +1255,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/enhancedbiomes.cfg
+++ b/base/tppi2/config/RTG/biomes/enhancedbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1015,44 +1015,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1097,44 +1097,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2090,44 +2090,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2172,44 +2172,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2503,44 +2503,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2588,44 +2588,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2670,44 +2670,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2752,44 +2752,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2834,44 +2834,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2916,44 +2916,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3247,44 +3247,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3329,44 +3329,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3411,44 +3411,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3493,44 +3493,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3575,44 +3575,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3657,44 +3657,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3739,44 +3739,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3821,44 +3821,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3903,44 +3903,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3985,44 +3985,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4067,44 +4067,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4149,44 +4149,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4231,44 +4231,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4313,44 +4313,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4395,44 +4395,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4477,44 +4477,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4559,44 +4559,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4641,44 +4641,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4723,44 +4723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4805,44 +4805,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4887,44 +4887,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4969,44 +4969,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5054,44 +5054,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5139,44 +5139,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5224,44 +5224,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5309,44 +5309,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5394,44 +5394,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5476,44 +5476,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5558,44 +5558,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5640,44 +5640,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5722,44 +5722,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5804,44 +5804,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5886,44 +5886,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5968,44 +5968,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6050,44 +6050,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6132,44 +6132,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6214,44 +6214,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6299,44 +6299,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6384,44 +6384,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6466,44 +6466,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6548,44 +6548,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6630,44 +6630,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6712,44 +6712,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6794,44 +6794,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6876,44 +6876,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6958,44 +6958,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7040,44 +7040,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7122,44 +7122,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7204,44 +7204,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7286,44 +7286,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7368,44 +7368,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/extrabiomes.cfg
+++ b/base/tppi2/config/RTG/biomes/extrabiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -930,44 +930,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1012,44 +1012,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1094,44 +1094,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1176,44 +1176,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1258,44 +1258,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1340,44 +1340,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1422,44 +1422,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1507,44 +1507,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2002,44 +2002,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2084,44 +2084,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2166,44 +2166,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2248,44 +2248,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/flowercraft.cfg
+++ b/base/tppi2/config/RTG/biomes/flowercraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/forgottennature.cfg
+++ b/base/tppi2/config/RTG/biomes/forgottennature.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/growthcraft.cfg
+++ b/base/tppi2/config/RTG/biomes/growthcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/highlands.cfg
+++ b/base/tppi2/config/RTG/biomes/highlands.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -687,44 +687,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1759,44 +1759,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1841,44 +1841,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1923,44 +1923,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2087,44 +2087,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2169,44 +2169,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2500,44 +2500,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2582,44 +2582,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2664,44 +2664,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2746,44 +2746,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2828,44 +2828,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2913,44 +2913,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3244,44 +3244,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3326,44 +3326,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3408,44 +3408,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3490,44 +3490,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/hotwatermod.cfg
+++ b/base/tppi2/config/RTG/biomes/hotwatermod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/icecreammod.cfg
+++ b/base/tppi2/config/RTG/biomes/icecreammod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/industrialtechnologies.cfg
+++ b/base/tppi2/config/RTG/biomes/industrialtechnologies.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,44 +113,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/inthedarkness.cfg
+++ b/base/tppi2/config/RTG/biomes/inthedarkness.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/ridiculousworld.cfg
+++ b/base/tppi2/config/RTG/biomes/ridiculousworld.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -116,44 +116,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -280,44 +280,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -362,44 +362,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -444,44 +444,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -526,44 +526,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/sugiforest.cfg
+++ b/base/tppi2/config/RTG/biomes/sugiforest.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/thaumcraft.cfg
+++ b/base/tppi2/config/RTG/biomes/thaumcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/tofucraft.cfg
+++ b/base/tppi2/config/RTG/biomes/tofucraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/vampirism.cfg
+++ b/base/tppi2/config/RTG/biomes/vampirism.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/biomes/vanilla.cfg
+++ b/base/tppi2/config/RTG/biomes/vanilla.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,34 +113,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -150,13 +150,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -204,34 +204,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -241,13 +241,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -295,44 +295,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -380,34 +380,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -417,13 +417,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -468,44 +468,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -553,44 +553,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -638,44 +638,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -723,44 +723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -805,34 +805,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -842,13 +842,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -893,44 +893,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -975,44 +975,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1057,44 +1057,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1142,34 +1142,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1185,13 +1185,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1239,34 +1239,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1282,13 +1282,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1333,34 +1333,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1376,13 +1376,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1430,34 +1430,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1467,13 +1467,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1518,34 +1518,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1555,13 +1555,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1609,34 +1609,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1646,13 +1646,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1700,34 +1700,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1737,13 +1737,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1791,34 +1791,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1828,13 +1828,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1879,34 +1879,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1916,13 +1916,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1967,44 +1967,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2049,34 +2049,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2092,13 +2092,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2146,44 +2146,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2240,44 +2240,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2328,34 +2328,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2365,13 +2365,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2419,44 +2419,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2504,44 +2504,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2592,44 +2592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2680,44 +2680,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2765,44 +2765,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2850,44 +2850,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2935,44 +2935,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3017,44 +3017,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3099,44 +3099,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3181,44 +3181,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3263,44 +3263,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3345,44 +3345,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3427,44 +3427,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3509,44 +3509,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3591,44 +3591,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3673,34 +3673,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -3710,13 +3710,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3761,44 +3761,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3846,44 +3846,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3928,44 +3928,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4016,34 +4016,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4053,13 +4053,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4107,34 +4107,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4144,13 +4144,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4198,34 +4198,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4235,13 +4235,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4289,44 +4289,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4371,44 +4371,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4453,44 +4453,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4535,44 +4535,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4617,44 +4617,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4702,44 +4702,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4787,44 +4787,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4872,44 +4872,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4957,44 +4957,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5042,44 +5042,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/tppi2/config/RTG/rtg.cfg
+++ b/base/tppi2/config/RTG/rtg.cfg
@@ -387,7 +387,7 @@ trees {
     B:"Allow Trees to Generate on Sand"=false
 
     # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-    # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+    # For more information, visit http://minecraft.wiki/w/Wood#Block_data
     #  [default: true]
     B:"Allow bark-covered logs"=true
 }

--- a/base/tppi2/config/iChunUtil_KeyBinds.cfg
+++ b/base/tppi2/config/iChunUtil_KeyBinds.cfg
@@ -7,7 +7,7 @@
 # iChunUtil uses custom keybinds. Go to the options page and hit O to show other options.
 # 
 # If you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.
-# For key codes go to: http://minecraft.gamepedia.com/Key_codes 
+# For key codes go to: http://minecraft.wiki/w/Key_codes 
 # Example: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt.
 ##########################################################################################################
 

--- a/base/unabridged/config/RTG/biomes/abyssalcraft.cfg
+++ b/base/unabridged/config/RTG/biomes/abyssalcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,34 +110,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -147,13 +147,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -201,34 +201,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -238,13 +238,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -289,34 +289,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -332,13 +332,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -383,44 +383,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -465,44 +465,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/arsmagica.cfg
+++ b/base/unabridged/config/RTG/biomes/arsmagica.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/atg.cfg
+++ b/base/unabridged/config/RTG/biomes/atg.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/biomesoplenty.cfg
+++ b/base/unabridged/config/RTG/biomes/biomesoplenty.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1267,44 +1267,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1349,44 +1349,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1434,44 +1434,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1519,44 +1519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1601,44 +1601,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1686,44 +1686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1771,44 +1771,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1853,44 +1853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1938,44 +1938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2023,44 +2023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2105,44 +2105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2187,44 +2187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2269,44 +2269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2354,44 +2354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2439,44 +2439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2521,44 +2521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2606,44 +2606,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2688,44 +2688,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2773,44 +2773,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2855,44 +2855,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2937,44 +2937,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3022,44 +3022,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3104,44 +3104,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3189,44 +3189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3271,44 +3271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3356,44 +3356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3438,44 +3438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3520,44 +3520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3602,44 +3602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3684,44 +3684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3769,44 +3769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3854,44 +3854,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3939,44 +3939,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4024,44 +4024,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4109,44 +4109,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4191,44 +4191,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4273,44 +4273,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4355,44 +4355,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4437,44 +4437,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4519,44 +4519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4604,44 +4604,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4686,44 +4686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4768,44 +4768,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4853,44 +4853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4938,44 +4938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5023,44 +5023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5105,44 +5105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5187,44 +5187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5269,44 +5269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5354,44 +5354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5439,44 +5439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5521,44 +5521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5603,44 +5603,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5685,44 +5685,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5767,44 +5767,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5852,44 +5852,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5934,44 +5934,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6016,44 +6016,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6098,44 +6098,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6180,44 +6180,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6262,44 +6262,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6344,44 +6344,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/buildcraft.cfg
+++ b/base/unabridged/config/RTG/biomes/buildcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/chromaticraft.cfg
+++ b/base/unabridged/config/RTG/biomes/chromaticraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/eccentricbiomes.cfg
+++ b/base/unabridged/config/RTG/biomes/eccentricbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -763,44 +763,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -845,44 +845,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -927,44 +927,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1009,44 +1009,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1091,44 +1091,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1173,44 +1173,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1255,44 +1255,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/enhancedbiomes.cfg
+++ b/base/unabridged/config/RTG/biomes/enhancedbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1015,44 +1015,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1097,44 +1097,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2090,44 +2090,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2172,44 +2172,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2503,44 +2503,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2588,44 +2588,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2670,44 +2670,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2752,44 +2752,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2834,44 +2834,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2916,44 +2916,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3247,44 +3247,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3329,44 +3329,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3411,44 +3411,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3493,44 +3493,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3575,44 +3575,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3657,44 +3657,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3739,44 +3739,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3821,44 +3821,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3903,44 +3903,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3985,44 +3985,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4067,44 +4067,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4149,44 +4149,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4231,44 +4231,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4313,44 +4313,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4395,44 +4395,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4477,44 +4477,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4559,44 +4559,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4641,44 +4641,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4723,44 +4723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4805,44 +4805,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4887,44 +4887,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4969,44 +4969,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5054,44 +5054,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5139,44 +5139,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5224,44 +5224,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5309,44 +5309,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5394,44 +5394,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5476,44 +5476,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5558,44 +5558,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5640,44 +5640,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5722,44 +5722,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5804,44 +5804,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5886,44 +5886,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5968,44 +5968,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6050,44 +6050,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6132,44 +6132,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6214,44 +6214,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6299,44 +6299,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6384,44 +6384,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6466,44 +6466,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6548,44 +6548,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6630,44 +6630,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6712,44 +6712,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6794,44 +6794,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6876,44 +6876,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6958,44 +6958,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7040,44 +7040,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7122,44 +7122,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7204,44 +7204,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7286,44 +7286,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7368,44 +7368,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/extrabiomes.cfg
+++ b/base/unabridged/config/RTG/biomes/extrabiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -930,44 +930,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1012,44 +1012,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1094,44 +1094,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1176,44 +1176,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1258,44 +1258,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1340,44 +1340,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1422,44 +1422,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1507,44 +1507,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2002,44 +2002,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2084,44 +2084,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2166,44 +2166,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2248,44 +2248,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/flowercraft.cfg
+++ b/base/unabridged/config/RTG/biomes/flowercraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/forgottennature.cfg
+++ b/base/unabridged/config/RTG/biomes/forgottennature.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/growthcraft.cfg
+++ b/base/unabridged/config/RTG/biomes/growthcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/highlands.cfg
+++ b/base/unabridged/config/RTG/biomes/highlands.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -687,44 +687,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1759,44 +1759,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1841,44 +1841,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1923,44 +1923,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2087,44 +2087,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2169,44 +2169,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2500,44 +2500,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2582,44 +2582,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2664,44 +2664,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2746,44 +2746,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2828,44 +2828,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2913,44 +2913,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3244,44 +3244,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3326,44 +3326,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3408,44 +3408,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3490,44 +3490,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/hotwatermod.cfg
+++ b/base/unabridged/config/RTG/biomes/hotwatermod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/icecreammod.cfg
+++ b/base/unabridged/config/RTG/biomes/icecreammod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/industrialtechnologies.cfg
+++ b/base/unabridged/config/RTG/biomes/industrialtechnologies.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,44 +113,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/inthedarkness.cfg
+++ b/base/unabridged/config/RTG/biomes/inthedarkness.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/ridiculousworld.cfg
+++ b/base/unabridged/config/RTG/biomes/ridiculousworld.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -116,44 +116,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -280,44 +280,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -362,44 +362,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -444,44 +444,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -526,44 +526,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/sugiforest.cfg
+++ b/base/unabridged/config/RTG/biomes/sugiforest.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/thaumcraft.cfg
+++ b/base/unabridged/config/RTG/biomes/thaumcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/tofucraft.cfg
+++ b/base/unabridged/config/RTG/biomes/tofucraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/vampirism.cfg
+++ b/base/unabridged/config/RTG/biomes/vampirism.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/biomes/vanilla.cfg
+++ b/base/unabridged/config/RTG/biomes/vanilla.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,34 +113,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -150,13 +150,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -204,34 +204,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -241,13 +241,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -295,44 +295,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -380,34 +380,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -417,13 +417,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -468,44 +468,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -553,44 +553,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -638,44 +638,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -723,44 +723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -805,34 +805,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -842,13 +842,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -893,44 +893,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -975,44 +975,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1057,44 +1057,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1142,34 +1142,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1185,13 +1185,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1239,34 +1239,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1282,13 +1282,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1333,34 +1333,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1376,13 +1376,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1430,34 +1430,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1467,13 +1467,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1518,34 +1518,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1555,13 +1555,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1609,34 +1609,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1646,13 +1646,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1700,34 +1700,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1737,13 +1737,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1791,34 +1791,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1828,13 +1828,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1879,34 +1879,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1916,13 +1916,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1967,44 +1967,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2049,34 +2049,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2092,13 +2092,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2146,44 +2146,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2240,44 +2240,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2328,34 +2328,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2365,13 +2365,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2419,44 +2419,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2504,44 +2504,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2592,44 +2592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2680,44 +2680,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2765,44 +2765,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2850,44 +2850,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2935,44 +2935,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3017,44 +3017,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3099,44 +3099,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3181,44 +3181,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3263,44 +3263,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3345,44 +3345,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3427,44 +3427,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3509,44 +3509,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3591,44 +3591,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3673,34 +3673,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -3710,13 +3710,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3761,44 +3761,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3846,44 +3846,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3928,44 +3928,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4016,34 +4016,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4053,13 +4053,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4107,34 +4107,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4144,13 +4144,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4198,34 +4198,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4235,13 +4235,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4289,44 +4289,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4371,44 +4371,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4453,44 +4453,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4535,44 +4535,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4617,44 +4617,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4702,44 +4702,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4787,44 +4787,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4872,44 +4872,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4957,44 +4957,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5042,44 +5042,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit http://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/base/unabridged/config/RTG/rtg.cfg
+++ b/base/unabridged/config/RTG/rtg.cfg
@@ -387,7 +387,7 @@ trees {
     B:"Allow Trees to Generate on Sand"=false
 
     # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-    # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+    # For more information, visit http://minecraft.wiki/w/Wood#Block_data
     #  [default: true]
     B:"Allow bark-covered logs"=true
 }

--- a/base/unabridged/config/iChunUtil_KeyBinds.cfg
+++ b/base/unabridged/config/iChunUtil_KeyBinds.cfg
@@ -7,7 +7,7 @@
 # iChunUtil uses custom keybinds. Go to the options page and hit O to show other options.
 # 
 # If you really have to edit the config file, the format is <key code>, and append either ":SHIFT", ":CTRL", or ":ALT" for keys you want to hold down at the same time.
-# For key codes go to: http://minecraft.gamepedia.com/Key_codes 
+# For key codes go to: http://minecraft.wiki/w/Key_codes 
 # Example: 48:SHIFT:ALT will bind to the B key when you hold Shift and Alt.
 ##########################################################################################################
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.