### PR TITLE
fix broken stronghold lewts

### DIFF
--- a/base/e32/world/datapacks/erisia/data/minecraft/loot_tables/chests/stronghold/library.json
+++ b/base/e32/world/datapacks/erisia/data/minecraft/loot_tables/chests/stronghold/library.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {"type": "minecraft:loot_table", "name": "minecraft:chests/stronghold_library"}
+      ]
+    }
+  ]
+}

--- a/base/e32/world/datapacks/erisia/data/minecraft/loot_tables/chests/stronghold/library_bookshelf.json
+++ b/base/e32/world/datapacks/erisia/data/minecraft/loot_tables/chests/stronghold/library_bookshelf.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {"type": "minecraft:loot_table", "name": "minecraft:chests/stronghold_library"}
+      ]
+    }
+  ]
+}

--- a/base/e32/world/datapacks/erisia/pack.mcmeta
+++ b/base/e32/world/datapacks/erisia/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "description": "Erisian fixes for misc datapack jank",
+        "pack_format": 10
+    }
+}


### PR DESCRIPTION
Turns out Dungeons and Taverns is the source of our cool stronghold, turns out it adds its own custom loot tables instead of just reusing the vanilla ones as well, this of course causes lots of fun issues.  A lot of the looting issues caused by it could probably be fixed with a similar issue but i'm out of my timebox for this atm.