### PR TITLE
Add Paper server support with GriefPrevention

### DIFF
--- a/base/server/start.py
+++ b/base/server/start.py
@@ -39,7 +39,7 @@ LOGS_DIR = APP_ROOT_DIR / "logs"
 GC_LOG_PATH = APP_ROOT_DIR / "gc.log"
 
 # Directories to rsync from BASE_DIR to APP_ROOT_DIR (need write access)
-RSYNC_DIRS = ["config", "world", "journeymap", "schematics", "defaultconfigs", "configureddefaults", "kubejs"]
+RSYNC_DIRS = ["config", "world", "journeymap", "schematics", "defaultconfigs", "configureddefaults", "kubejs", "plugins"]
 
 # --- Global State ---
 java_server_process = None # Popen object for systemd-run or direct Java process
@@ -505,6 +505,18 @@ def main():
         )
         nix_jre_package = "jre"
         server_specific_args = ['-jar', str(selected_cleanroom_jar), 'nogui']
+    elif (BASE_DIR / "paper" / "server.jar").is_file():
+        paper_jar = BASE_DIR / "paper" / "server.jar"
+        server_type_panel = Panel(
+            f"[bold]Paper Server[/]\nJAR: {paper_jar}\nJRE: Java 25",
+            style="green"
+        )
+        nix_jre_package = "jdk25"
+        server_specific_args = ['-jar', str(paper_jar), 'nogui']
+        eula_file = APP_ROOT_DIR / "eula.txt"
+        if not eula_file.exists():
+            eula_file.write_text("eula=true\n")
+            console.print("[green]Created eula.txt (EULA accepted)[/]")
     elif (BASE_DIR / "vanilla" / "server.jar").is_file():
         vanilla_jar = BASE_DIR / "vanilla" / "server.jar"
         server_type_panel = Panel(

--- a/base/server/start.py
+++ b/base/server/start.py
@@ -380,7 +380,10 @@ def main():
     server_info.add_row("Script PID", str(os.getpid()))
     console.print(server_info)
 
-    if check_systemd():
+    if os.environ.get("SKIP_SYSTEMD"):
+        console.print("[yellow]SKIP_SYSTEMD is set. Skipping systemd-run; using direct process management.[/]")
+        using_systemd = False
+    elif check_systemd():
         console.print("[green]systemd detected. Will use systemd-run for managing the server process.[/]")
         using_systemd = True
     else:

--- a/builder.nix
+++ b/builder.nix
@@ -24,7 +24,7 @@ rec {
     port = 25566;
     prometheusPort = 1226;
     minecraft = "1.21.11";
-    vanilla = true;
+    paper = true;
     extraServerDirs = [
       ./base/vanilla-server
       ./base/server

--- a/builder.nix
+++ b/builder.nix
@@ -19,11 +19,11 @@ rec {
   vanilla = {
     name = "Vanilla";
     tmuxName = "vanilla";
-    description = "Vanilla Minecraft 1.21.11";
+    description = "Vanilla Minecraft 26.1.2";
     ram = "4G";
     port = 25566;
     prometheusPort = 1226;
-    minecraft = "1.21.11";
+    minecraft = "26.1.2";
     paper = true;
     extraServerDirs = [
       ./base/vanilla-server

--- a/launcher-lock.json
+++ b/launcher-lock.json
@@ -1,4 +1,10 @@
 {
+  "paper": {
+    "1.21.11": {
+      "url": "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar",
+      "sha256": "sha256-zzdPKvnXHfzHU0Pze3IqerywkcV0ExuV47E8b8LLj64="
+    }
+  },
   "vanilla": {
     "1.21.11": {
       "url": "https://piston-data.mojang.com/v1/objects/64bb6d763bed0a9f1d632ec347938594144943ed/server.jar",

--- a/launcher-lock.json
+++ b/launcher-lock.json
@@ -3,6 +3,10 @@
     "1.21.11": {
       "url": "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar",
       "sha256": "sha256-zzdPKvnXHfzHU0Pze3IqerywkcV0ExuV47E8b8LLj64="
+    },
+    "26.1.2": {
+      "url": "https://fill-data.papermc.io/v1/objects/0555a0b0468a5198d8fb1a16e1f9e95c81a917a2dc8f2e09867b4044742f6401/paper-26.1.2-72.jar",
+      "sha256": "sha256-BVWgsEaKUZjY+xoW4fnpXIGpF6Lcjy4JhntARHQvZAE="
     }
   },
   "vanilla": {

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -36,6 +36,7 @@ rec {
     neoforge ? null,
     cleanroom ? null,
     vanilla ? false,
+    paper ? false,
     client-forge ? null,
     ram ? "4000m",
     manifest,
@@ -95,12 +96,16 @@ rec {
       vanillaDir = wrapDir "vanilla" (fetchVanilla {
         minecraft = minecraft;
       });
+      paperDir = wrapDir "paper" (fetchPaper {
+        minecraft = minecraft;
+      });
       forgeDir = wrapDir "forge" (if neoforge != null then fetchNeoForge neoforge
                                   else if cleanroom != null then fetchCleanroom cleanroom
                                   else fetchForge forge
       );
     in if fabric != null then fabricDir
        else if vanilla then vanillaDir
+       else if paper then paperDir
        else forgeDir;
 
     serverMods = filterManifest {
@@ -117,7 +122,7 @@ rec {
 
       paths = [
         launcherDir
-        (wrapDir "mods" serverModsDir)
+        (if paper then wrapDir "plugins" serverModsDir else wrapDir "mods" serverModsDir)
         (callPackage ../tools/control {})
       ] ++ extraServerDirs ++ extraDirs;
 
@@ -153,6 +158,19 @@ rec {
       inherit (locked) url sha256;
     };
   in runCommand "vanilla-${minecraft}" {
+    inherit serverJar;
+  } ''
+    mkdir $out
+    cp $serverJar $out/server.jar
+  '';
+
+  fetchPaper = { minecraft }: let
+    locked = launcherLock.paper.${minecraft};
+    serverJar = fetchurl {
+      name = "paper-server-${minecraft}.jar";
+      inherit (locked) url sha256;
+    };
+  in runCommand "paper-${minecraft}" {
     inherit serverJar;
   } ''
     mkdir $out

--- a/manifest/vanilla.json
+++ b/manifest/vanilla.json
@@ -1,1 +1,15 @@
-[]
+[
+  {
+    "name": "griefprevention",
+    "title": "GriefPrevention",
+    "side": "server",
+    "required": true,
+    "default": true,
+    "filename": "GriefPrevention.jar",
+    "encoded": "GriefPrevention.jar",
+    "src": "https://cdn.modrinth.com/data/O4o4mKaq/versions/dGfCZHqk/GriefPrevention.jar",
+    "size": 380232,
+    "md5": "0b3fed989d35eb6194273d8981a19c28",
+    "sha256": "45e9907c61222e559ed2e099ffee0ede706a21243a31d7db549baf678708fdf0"
+  }
+]


### PR DESCRIPTION
Switches the vanilla server from plain Minecraft to Paper, enabling plugin support. GriefPrevention is added as the first plugin to protect player builds.

Tested and running in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)